### PR TITLE
add `--enable-fat` for easy cross-compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "buildsInSource": true,
     "build": [
       "find ./ -exec touch -t 200905010101 {} +",
-      "./configure --prefix=#{self.install} #{os == 'windows' ? '--host x86_64-w64-mingw32' : ''} --with-pic",
+      "./configure --enable-fat --prefix=#{self.install} #{os == 'windows' ? '--host x86_64-w64-mingw32' : ''} --with-pic",
       "make"
     ],
     "install": [


### PR DESCRIPTION
GMP uses [Intel ADX](https://en.wikipedia.org/wiki/Intel_ADX) to do math stuff when capable for performance reasons. The pick whether to use ADX or not is being chosen on compile time, unless you specify `--enable-fat` which creates a "fat" binary that decides on runtime whether to use these custom instructions:

> Using --enable-fat selects a “fat binary” build on x86, where optimized low level subroutines are chosen at runtime according to the CPU detected. This means more code, but gives good performance on all x86 chips. (This option might become available for more architectures in the future.)

Without this flag, users can get "illegal hardware instruction" errors when running their binaries on a machine without Intel ADX.

So, in other words, this PR enables building gmp into a binary on CI which _has Intel ADX_, and then using it on a machine that does not have it (like AMD or older Intels)

To me, it sounds like a sane default.

see https://github.com/Schniz/fnm/pull/177 for more information


Thanks @ulrikstrid for pointing me to it!