### PR TITLE
Get gmp-lib from GNU ftp mirror

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "esy-gmp",
   "version": "6.2.0",
   "description": "GMP packaged for esy",
-  "source": "https://gmplib.org/download/gmp/gmp-6.2.1.tar.xz#0578d48607ec0e272177d175fd1807c30b00fdf2",
+  "source": "https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.xz#0578d48607ec0e272177d175fd1807c30b00fdf2",
   "override": {
     "buildsInSource": true,
     "build": [


### PR DESCRIPTION
`gmp.org` has blocked Microsoft IPs, so GitHub actions fails when building this.
The package seems to be available via https://ftp.gnu.org .

I found out the cause of this problem from [here](https://github.com/pmmp/PocketMine-Docker/issues/24).